### PR TITLE
Don't crash the UI when getting the project list fails

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -81,7 +81,12 @@ class PageController extends Controller {
 			'project_list' => [],
 		];
 		if ($url !== '' && $token !== '' && $refreshToken !== '') {
-			$pageInitialState['project_list'] = $this->collaboardAPIService->getProjects($this->userId);
+			$projects = $this->collaboardAPIService->getProjects($this->userId);
+			if (isset($projects['error'])) {
+				$pageInitialState['project_list_error'] = $projects['error'];
+			} else {
+				$pageInitialState['project_list'] = $projects;
+			}
 		}
 		$this->initialStateService->provideInitialState('collaboard-state', $pageInitialState);
 		return new TemplateResponse(Application::APP_ID, 'main', []);

--- a/lib/Service/CollaboardAPIService.php
+++ b/lib/Service/CollaboardAPIService.php
@@ -238,7 +238,7 @@ class CollaboardAPIService {
 				'exception' => $e->getMessage(),
 			]);
 			return [
-				'error' => 'Collaboard API client error',
+				'error' => $this->l10n->t('Collaboard API client error'),
 				'responseBody' => $responseBody,
 				'exception' => $e->getMessage(),
 			];

--- a/src/App.vue
+++ b/src/App.vue
@@ -31,6 +31,13 @@
 					:show-title="false"
 					@connected="onConnected" />
 			</div>
+			<NcEmptyContent v-else-if="state.project_list_error"
+				:title="t('integration_collaboard', 'Failed to get the project list')"
+				:description="state.project_list_error">
+				<template #icon>
+					<CollaboardIcon />
+				</template>
+			</NcEmptyContent>
 			<NcEmptyContent v-else-if="activeProjectCount === 0 && loadingProjects"
 				:title="t('integration_collaboard', 'Loading project list')">
 				<template #icon>
@@ -148,6 +155,9 @@ export default {
 			return this.state.licensing_info?.IsActive
 		},
 		activeProjects() {
+			if (this.state.project_list_error) {
+				return []
+			}
 			return this.state.project_list.filter((b) => !b.trash).sort((a, b) => {
 				const ta = moment(a.updated_at).unix()
 				const tb = moment(b.updated_at).unix()


### PR DESCRIPTION
Basic fix. Shows what's returned by the service `restRequest` method in the UI.