### PR TITLE
Fix project thumbnails

### DIFF
--- a/src/components/ProjectItem.vue
+++ b/src/components/ProjectItem.vue
@@ -59,7 +59,7 @@ export default {
 
 	computed: {
 		hasImage() {
-			return this.project.Project.Thumbnail !== null
+			return !!this.project.Project.Thumbnail
 		},
 		imgSrc() {
 			return 'data:image/png;base64,' + this.project.Project.Thumbnail


### PR DESCRIPTION
Thumbnails used to be in the project list response as base64. Now we get a URL.
This adjustment is on the backend only. Out frontend stays the same.