### PR TITLE
Fix wrong param when calling appManager->isEnabledForUser

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -64,7 +64,7 @@ class PageController extends Controller {
 
 		$sfaMethod = $this->config->getUserValue($this->userId, Application::APP_ID, 'sfa_method', Application::DEFAULT_2FA_METHOD) ?: Application::DEFAULT_2FA_METHOD;
 
-		$talkEnabled = $this->appManager->isEnabledForUser('spreed', $this->userId);
+		$talkEnabled = $this->appManager->isEnabledForUser('spreed');
 
 		$licensingInfo = $this->collaboardAPIService->getUserLicenseInfo($this->userId);
 


### PR DESCRIPTION
It used to work with NC < 27. Not anymore.