### PR TITLE
build: update node and npm engines versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,61 +1,61 @@
 {
-	"name": "integration_collaboard",
-	"version": "0.0.1",
-	"description": "Collaboard integration",
-	"main": "index.js",
-	"directories": {
-		"test": "tests"
-	},
-	"scripts": {
-		"build": "NODE_ENV=production webpack --progress --config webpack.js",
-		"dev": "NODE_ENV=development webpack --progress --config webpack.js",
-		"watch": "NODE_ENV=development webpack --progress --watch --config webpack.js",
-		"lint": "eslint --ext .js,.vue src",
-		"lint:fix": "eslint --ext .js,.vue src --fix",
-		"stylelint": "stylelint src/**/*.vue src/**/*.scss src/**/*.css",
-		"stylelint:fix": "stylelint src/**/*.vue src/**/*.scss src/**/*.css --fix"
-	},
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/julien-nc/integration_collaboard"
-	},
-	"keywords": [
-		"collaboard"
-	],
-	"author": "Julien Veyssier",
-	"license": "AGPL-3.0",
-	"bugs": {
-		"url": "https://github.com/julien-nc/integration_collaboard/issues"
-	},
-	"homepage": "https://github.com/julien-nc/integration_collaboard",
-	"browserslist": [
-		"extends @nextcloud/browserslist-config"
-	],
-	"dependencies": {
-		"@nextcloud/auth": "^2.0.0",
-		"@nextcloud/axios": "^2.0.0",
-		"@nextcloud/dialogs": "^5.0.3",
-		"@nextcloud/initial-state": "^2.0.0",
-		"@nextcloud/l10n": "^2.0.1",
-		"@nextcloud/moment": "^1.3.1",
-		"@nextcloud/router": "^3.0.0",
-		"@nextcloud/vue": "^8.3.0",
-		"@nextcloud/vue-dashboard": "^2.0.1",
-		"vue": "^2.6.14",
-		"vue-clipboard2": "^0.3.3",
-		"vue-material-design-icons": "^5.1.2"
-	},
-	"engines": {
-		"node": "^16.0.0",
-		"npm": "^7.0.0 || ^8.0.0"
-	},
-	"devDependencies": {
-		"@nextcloud/babel-config": "^1.0.0",
-		"@nextcloud/browserslist-config": "^3.0.0",
-		"@nextcloud/eslint-config": "^8.0.0",
-		"@nextcloud/stylelint-config": "^2.1.2",
-		"@nextcloud/webpack-vue-config": "^6.0.0",
-		"eslint-webpack-plugin": "^4.0.0",
-		"stylelint-webpack-plugin": "^5.0.0"
-	}
+  "name": "integration_collaboard",
+  "version": "0.0.1",
+  "description": "Collaboard integration",
+  "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "build": "NODE_ENV=production webpack --progress --config webpack.js",
+    "dev": "NODE_ENV=development webpack --progress --config webpack.js",
+    "watch": "NODE_ENV=development webpack --progress --watch --config webpack.js",
+    "lint": "eslint --ext .js,.vue src",
+    "lint:fix": "eslint --ext .js,.vue src --fix",
+    "stylelint": "stylelint src/**/*.vue src/**/*.scss src/**/*.css",
+    "stylelint:fix": "stylelint src/**/*.vue src/**/*.scss src/**/*.css --fix"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/julien-nc/integration_collaboard"
+  },
+  "keywords": [
+    "collaboard"
+  ],
+  "author": "Julien Veyssier",
+  "license": "AGPL-3.0",
+  "bugs": {
+    "url": "https://github.com/julien-nc/integration_collaboard/issues"
+  },
+  "homepage": "https://github.com/julien-nc/integration_collaboard",
+  "browserslist": [
+    "extends @nextcloud/browserslist-config"
+  ],
+  "dependencies": {
+    "@nextcloud/auth": "^2.0.0",
+    "@nextcloud/axios": "^2.0.0",
+    "@nextcloud/dialogs": "^5.0.3",
+    "@nextcloud/initial-state": "^2.0.0",
+    "@nextcloud/l10n": "^2.0.1",
+    "@nextcloud/moment": "^1.3.1",
+    "@nextcloud/router": "^3.0.0",
+    "@nextcloud/vue": "^8.3.0",
+    "@nextcloud/vue-dashboard": "^2.0.1",
+    "vue": "^2.6.14",
+    "vue-clipboard2": "^0.3.3",
+    "vue-material-design-icons": "^5.1.2"
+  },
+  "engines": {
+    "node": "^24.0.0",
+    "npm": "^11.3.0"
+  },
+  "devDependencies": {
+    "@nextcloud/babel-config": "^1.0.0",
+    "@nextcloud/browserslist-config": "^3.0.0",
+    "@nextcloud/eslint-config": "^8.0.0",
+    "@nextcloud/stylelint-config": "^2.1.2",
+    "@nextcloud/webpack-vue-config": "^6.0.0",
+    "eslint-webpack-plugin": "^4.0.0",
+    "stylelint-webpack-plugin": "^5.0.0"
+  }
 }


### PR DESCRIPTION
Automated update of the npm and node engines versions according to [Nextcloud standards](https://github.com/nextcloud/standards/issues/5).